### PR TITLE
Fix not download files because of an early throw error.

### DIFF
--- a/lib/schedule-run.js
+++ b/lib/schedule-run.js
@@ -164,13 +164,16 @@ exports.scheduleRun = async function (params) {
                      ", " + err);
             }
         }
-        throw("Test run failed after " + i*wait_interval + " seconds with: " + run_status.run.resultCode + ". Timeout is set to " + max_wait*wait_interval);
     }
 
     run.downloaded_artifacts = await artifacts.getArtifact({file_artifacts: params.file_artifacts,
                                                             screenshot_artifacts: params.screenshot_artifacts,
                                                             log_artifacts: params.log_artifacts,
                                                             arn: run.run.arn});
+
+    if (run_status.run.result != "PASSED") {
+        throw("Test run failed after " + i*wait_interval + " seconds with: " + run_status.run.resultCode + ". Timeout is set to " + max_wait*wait_interval);
+    }
 
     return run_status;
 }


### PR DESCRIPTION
When the test was finished with an error, I realized that the customer artifact file have not been downloaded. So I put throw section after the downloaded artifacts.